### PR TITLE
Optimise from grid 

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,9 +6,9 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1', '1.4']
+        julia-version: ['1', '1.6']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest, windows-latest]
           

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NelderMead"
 uuid = "2f6b4ddb-b4ff-44c0-b59b-2ab99302f970"
 authors = ["James Cook <cookjws@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [compat]
 julia = "1"

--- a/src/NelderMead.jl
+++ b/src/NelderMead.jl
@@ -63,7 +63,6 @@ function optimise(f::F, lower::Container, upper::Container,
     inds2vals[index] = f(x)
   end
   if haskey(kwargs, :stepsize)
-    (_, indmin) = findmin(values, inds2vals)
     indmin = reduce((a, b)->inds2vals[a] <= inds2vals[b] ? a : b, keys(inds2vals))
     return optimise!(Simplex(f, inds2positions(indmin), kwargs[:stepsize]), f;
       kwargs...)

--- a/src/Simplexes.jl
+++ b/src/Simplexes.jl
@@ -32,7 +32,10 @@ function Simplex(f::T, positions::U
   map(i->push!(vertices, Vertex(positions[i], f(positions[i]))), 2:dim+1)
   return Simplex(vertices)
 end
-
+function Simplex(f::T, ic::AbstractVector{U}, initial_step::Number
+    ) where {T<:Function, U<:Number}
+  return Simplex(f, ic, [initial_step for _ in eachindex(ic)])
+end
 
 import Base: length, iterate, push!, iterate, getindex
 import Base: eachindex, sort!, hash

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,9 +40,13 @@ Random.seed!(0)
       for N ∈ 1:3
         gridsize = [rand(1:3) for i ∈ 1:N]
         solutions = NelderMead.optimise(x->objective(x, N), zeros(N), ones(N), gridsize,
-                                    stopval=stopval, maxiters=100_000)
+           stopval=stopval, maxiters=100_000)
         @assert length(solutions) >= 1
         test_solution.(solutions, N)
+
+        solution = NelderMead.optimise(x->objective(x, N), zeros(N), ones(N), gridsize,
+          stepsize=0.1, stopval=stopval, maxiters=100_000)
+        test_solution(solution, N)
       end
     end
     @testset "Errors are caught" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ Random.seed!(0)
     end
     @testset "Grid optimise" begin
       for N ∈ 1:3
-        gridsize = [rand(1:3) for i ∈ 1:N]
+        gridsize = [rand(2:4) for i ∈ 1:N]
         solutions = NelderMead.optimise(x->objective(x, N), zeros(N), ones(N), gridsize,
            stopval=stopval, maxiters=100_000)
         @assert length(solutions) >= 1


### PR DESCRIPTION
Added a stepsize kwarg when optimising from a grid, which selects the best vertex from which to start the standard Nelder Mead routine, rather than performing NM from all simplexes on the grid.